### PR TITLE
Add zhaobiao spider tool card and API

### DIFF
--- a/backend/tools/zhaobiao_spider/main.py
+++ b/backend/tools/zhaobiao_spider/main.py
@@ -35,7 +35,7 @@ def run(equal: str, rn: int, outfmt: str, start: str | None, end: str | None, no
     total = (data0.get('result') or {}).get('totalcount', 0)
     print(f"总记录数: {total}")
     if total <= 0:
-        return
+        return None
 
     pages = math.ceil(total / rn)
     proc = get_processor(equal)
@@ -53,17 +53,20 @@ def run(equal: str, rn: int, outfmt: str, start: str | None, end: str | None, no
         time.sleep(0.4)
 
     ts = datetime.now().strftime('%Y%m%d_%H%M%S')
-    outbase = f'./output/{equal}_{ts}'
+    outbase = os.path.abspath(f'./output/{equal}_{ts}')
     if outfmt == 'csv':
         save_csv(f'{outbase}.csv', rows)
-        print(f'CSV: {outbase}.csv')
+        main_file = f'{outbase}.csv'
+        print(f'CSV: {main_file}')
     else:
         save_json(f'{outbase}.json', rows)
-        print(f'JSON: {outbase}.json')
+        main_file = f'{outbase}.json'
+        print(f'JSON: {main_file}')
 
     with open(f'{outbase}_raw.json', 'w', encoding='utf-8') as f:
         json.dump(raw_pages, f, ensure_ascii=False, indent=2)
     print(f'原始JSON: {outbase}_raw.json')
+    return main_file
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -93,6 +93,48 @@
     <p id="extract-status" class="text-sm text-gray-600"></p>
   </div>
 
+  <!-- ====== 招标爬虫，工具3 ====== -->
+  <div class="w-full max-w-lg bg-white shadow rounded-2xl p-6 space-y-4">
+    <h2 class="text-2xl font-semibold">工具3：招标爬虫</h2>
+
+    <label class="block text-sm font-medium text-gray-700">类型代码（equal）：</label>
+    <input id="spider-equal"
+           type="text"
+           value="002001009"
+           class="w-full border rounded p-2 text-sm"/>
+
+    <div class="grid grid-cols-2 gap-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-700">开始日期</label>
+        <input id="spider-start" type="date" class="w-full border rounded p-2 text-sm"/>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">结束日期</label>
+        <input id="spider-end" type="date" class="w-full border rounded p-2 text-sm"/>
+      </div>
+    </div>
+
+    <label class="block text-sm font-medium text-gray-700">输出格式</label>
+    <select id="spider-format" class="w-full border rounded p-2 text-sm">
+      <option value="csv">CSV</option>
+      <option value="json">JSON</option>
+    </select>
+
+    <button id="btn-spider" class="w-full px-4 py-2 bg-blue-600 text-white rounded-lg">
+      开始爬取
+    </button>
+
+    <div id="spider-spinner" class="w-full mt-4 hidden flex items-center space-x-2">
+      <svg class="animate-spin h-5 w-5 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
+      </svg>
+      <span class="text-blue-600">爬取中，请稍候…</span>
+    </div>
+
+    <p id="spider-status" class="text-sm text-gray-600"></p>
+  </div>
+
   <script src="static/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add API endpoint for zhaobiao spider and allow downloads of generated files
- return file path from zhaobiao spider run
- add card and JS logic on frontend to trigger spider

## Testing
- `python -m py_compile backend/app.py backend/tools/zhaobiao_spider/main.py`
- `node --check frontend/static/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a33df40300832c92cf38527be11350